### PR TITLE
Update spacer.rb to allow building from source

### DIFF
--- a/Formula/spacer.rb
+++ b/Formula/spacer.rb
@@ -1,17 +1,31 @@
 class Spacer < Formula
-  version '0.1.8'
+  version "0.1.8"
   desc "A small command-line utility for adding spacers to command output"
   homepage "https://github.com/samwho/spacer"
+  head "https://github.com/samwho/spacer.git", branch: "main"
 
-  if OS.mac?
+  on_intel do
+    if OS.mac?
       url "https://github.com/samwho/spacer/releases/download/v#{version}/spacer-x86_64-apple-darwin.tar.gz"
       sha256 "c244f98faa581105051278827705cbb3e6c6d40d6d956d9aa483fcefe11b4b57"
-  elsif OS.linux?
+    elsif OS.linux?
       url "https://github.com/samwho/spacer/releases/download/v#{version}/spacer-x86_64-unknown-linux-musl.tar.gz"
       sha256 "c127514d126bb369003ccbce72a4d147c9447ff0bf055e37c858fac6b92dd34a"
+    end
+
+    def install
+      bin.install "spacer"
+    end
   end
 
-  def install
-    bin.install "spacer"
+  on_arm do
+    depends_on "rust" => :build
+
+    url "https://github.com/samwho/spacer/archive/refs/tags/v#{version}.tar.gz"
+    sha256 "f50133bfef2b2bf3c5eb40fd7da06fd030f24dffb71557668ac919471bf49048"
+
+    def install
+      system "cargo", "install", *std_cargo_args
+    end
   end
 end


### PR DESCRIPTION
See https://github.com/samwho/spacer/issues/11

I'm not sure if this brew Formular was generated or not. If that's the case, let me know where and how and I'll take a look how to get these changes in there.

I think this is more like a bandaid and offering pre-compiled binaries at least for arm64-darwin would be great (compiling with Rust is slow and Apple Silicon will become dominant quickly).

What this PR does:

* **on intel/x86**: same behaviour as before (pre-build binaries will be downloaded from the release)
* **on arm**: as there are no pre-build binaries, configure the Formula to build from source using cargo.

In other words: On macOS on Apple Silicon (or Linux aarch) `brew install spacer` will always compile, while on x86 it will download the pre-build binaries.

In general the changes also allow to build from source regardless of architecture, if you want, and in addition build from head too:

```terminal
brew install --HEAD spacer
brew install --build-from-source spacer
```

## Also

* the indentation was of, which I fixed
* use double quotes consistently for String literals